### PR TITLE
Make 4.0 Happy

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -226,7 +226,7 @@ define account(
 
     $defaults = {
       ensure => $ensure,
-      type   => 'ssh-rsa',
+      'type'   => 'ssh-rsa',
       user   => $username,
     }
 


### PR DESCRIPTION
Puppet 4.0 is not happy that the defined field "type" is not quoted. Adding this single ' ' allows the puppet run to complete without issue. Tested that this value works by running to completion and also removing the set values later in the file to confirm the default value works as expected with these new quotes.
